### PR TITLE
DM-31071: Removed the Rubin Observatory software stack and all Java r…

### DIFF
--- a/rpi4-centos7-docker-img.gz
+++ b/rpi4-centos7-docker-img.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c624fadb6e4ddd1ea083dcd3ebcd385e0f44bc86d80ee1e00001fc425abfeb3a
-size 1531415409
+oid sha256:d02f085945a00186a057e1116625ac4627dedcd972455d704e0bb06f8bbaf40e
+size 1249355235


### PR DESCRIPTION
…elated packages. Added minicom and updated CentOS.